### PR TITLE
be nice to developers using lower-case headers.

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -24,6 +24,12 @@ function handleRequest (details) {
     return {requestHeaders: details.requestHeaders};
 }
 
+// Though RFC 7230 says HTTP headers should be case-sensitive,
+// we could be nice to developers using lower-case headers.
+function lowerCaseEqual(a, b) {
+    return typeof a === 'string' && a.toLowerCase() === b;
+}
+
 function handleRespone (details) {
     var header = null,
         allowHeaders = getAllowHeader(),
@@ -33,11 +39,11 @@ function handleRespone (details) {
     for (var i = 0, len = details.responseHeaders.length; i < len; ++i) {
         header = details.responseHeaders[i];
         if (!originFound || !headerFound) {
-            if (header.name === 'Access-Control-Allow-Origin') {
+            if (lowerCaseEqual(header.name, 'access-control-allow-origin')) {
                 //header.value = origin;
                 originFound = true;
             }
-            else if (header.name === 'Access-Control-Allow-Headers') {
+            else if (lowerCaseEqual(header.name, 'access-control-allow-headers')) {
                 //header.value += ',' + allowHeaders.join(',');
                 headerFound = true;
             }


### PR DESCRIPTION
Though RFC 7230 says HTTP headers should be case-sensitive, we could be nice:
1. Send only case-sensitive headers.
2. Also accept developers using lower-case headers.

In my case, when I visit accounts.google.com, the request failed because we add `Access-Control-Allow-Origin: *` after the original response header `access-control-allow-origin: accounts.google.com`. `Access-Control-Allow-Origin: accounts.google.com, *` is not allowed by Chrome and the request would fail.

![image](https://user-images.githubusercontent.com/6082721/29157154-30e322ac-7d6b-11e7-9169-d303895379cb.png)
